### PR TITLE
Fix/argument type

### DIFF
--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/wavelet/WaveletDenoize.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/wavelet/WaveletDenoize.java
@@ -153,10 +153,10 @@ public class WaveletDenoize {
 			detected = false;
 		}
 
-		float margin = 0.05f;
+		double margin = 0.05;
 
 		if(detected0&&detected){
-			boolean morelwpeak = moreThanParcentLowArea(0.02f,loh-margin, dlist);
+			boolean morelwpeak = moreThanParcentLowArea(0.02,loh - margin, dlist);
 			if(morelwpeak){
 				return Math.min(loh0,loh);
 			}else{
@@ -240,10 +240,10 @@ public class WaveletDenoize {
 			if (firstPeak[0] < secondPeak[0]) {
 				return (float) firstPeak[0];
 			} else {
-				float parcent = 0.03f;
-				float margin = 0.05f;
+				double parcent = 0.03;
+				double margin = 0.05;
 				if (firstPeak[0] - margin> secondPeak[0]) {
-					if (moreThanParcentLowArea(parcent, firstPeak[0]-margin, dlist)) {
+					if (moreThanParcentLowArea(parcent, firstPeak[0] - margin, dlist)) {
 						return (float) secondPeak[0];
 					}
 				}
@@ -252,7 +252,7 @@ public class WaveletDenoize {
 		}
 	}
 
-	private static boolean moreThanParcentLowArea(float f, double firstPeak,
+	private static boolean moreThanParcentLowArea(double f, double firstPeak,
 			List<List<WaveletIF>> dlist) {
 		try {
 			long total = 0;

--- a/src/test/java/jp/ac/utokyo/rcast/karkinos/wavelet/WaveletDenoizeTest.java
+++ b/src/test/java/jp/ac/utokyo/rcast/karkinos/wavelet/WaveletDenoizeTest.java
@@ -378,7 +378,7 @@ public class WaveletDenoizeTest {
                 Arguments.of(
                         l5, l5,
                         deNoiseValue2,
-                        0.2f));
+                        0.3f));
     }
 
     @ParameterizedTest
@@ -412,17 +412,17 @@ public class WaveletDenoizeTest {
 
         return Stream.of(
                 //f, firstPeak, deNoiseValues, expected
-                Arguments.of(0.99f, 0.71, deNoiseValues, true),
-                Arguments.of(1.0f, 0.71, deNoiseValues, false),
-                Arguments.of(1.01f, 0.71, deNoiseValues, false),
-                Arguments.of(0.019f, 0.70, deNoiseValues, true),
-                Arguments.of(0.02f, 0.70, deNoiseValues, true),
-                Arguments.of(0.021f, 0.70, deNoiseValues, false));
+                Arguments.of(0.99, 0.71, deNoiseValues, true),
+                Arguments.of(1.0, 0.71, deNoiseValues, false),
+                Arguments.of(1.01, 0.71, deNoiseValues, false),
+                Arguments.of(0.019, 0.70, deNoiseValues, true),
+                Arguments.of(0.02, 0.70, deNoiseValues, false),
+                Arguments.of(0.021, 0.70, deNoiseValues, false));
     }
 
     @ParameterizedTest
     @MethodSource("moreThanParcentLowAreaParameters")
-    void moreThanParcentLowAreaTest(final float f,
+    void moreThanParcentLowAreaTest(final double f,
                                     final double firstPeak,
                                     final double[][] deNoiseValues,
                                     final boolean expected) {


### PR DESCRIPTION
In the `moreThanParcentLowArea` function, due to the difference in the types of float and double, 
there was a case where unintended operation was performed in the case of boundary values when comparing values.
Change the argument type from float to double.