### PR TITLE
Add TerminalMismatch and SoftClipExtention filters

### DIFF
--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/KarkinosProp.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/KarkinosProp.java
@@ -133,7 +133,23 @@ public class KarkinosProp implements java.io.Serializable {
 	public static String KEY_nearindelbt  ="nearindelbt";
 	public static String KEY_baysianFilterdepth  ="baysianFilterdepth";
 
+	//2020.12.18 H.Ueda
+	public static int extraReadTerminalCheckLen = 20;
+	public static int extraReadTerminalMismatchThres = 2;
+	public static float TerminalMismatchNGThres = 0.4f;
+
+	public static String Key_extraReadTerminalCheckLen = "extraReadTerminalCheckLen";
+	public static String Key_extraReadTerminalMismatchThres = "extraReadTerminalMismatchThres";
+	public static String Key_TerminalMismatchNGThres = "TerminalMismatchNGThres";
+
+
 	private static void loadEach() {
+
+		//2020.12.18 H.Ueda
+		extraReadTerminalCheckLen = getIntProperty(KEY_denozeToSD,(int)extraReadTerminalCheckLen);
+		extraReadTerminalMismatchThres = getIntProperty(Key_extraReadTerminalMismatchThres,(int)extraReadTerminalMismatchThres);
+		TerminalMismatchNGThres = getFloatProperty(Key_TerminalMismatchNGThres,(float)TerminalMismatchNGThres);
+
 		BINBITSIZE = getIntProperty(KEY_BINBITSIZE,BINBITSIZE);
 		denozeToSD = getFloatProperty(KEY_denozeToSD,(float)denozeToSD);
 		maxdenoiseLevel = getIntProperty(KEY_maxdenoiseLevel,maxdenoiseLevel);
@@ -158,7 +174,7 @@ public class KarkinosProp implements java.io.Serializable {
 		minPhredQual = getFloatProperty(KEY_minPhredQual,minPhredQual);
 		minMappability = getFloatProperty(KEY_minMappability,minMappability);
 		minEntropy = getFloatProperty(KEY_minEntropy,minEntropy);
-		minMisMatchRate = getFloatProperty(KEY_minMisMatchRate,minMisMatchRate);
+		//minMisMatchRate = getFloatProperty(KEY_minMisMatchRate,minMisMatchRate);
 
 		Fisher_Thres_For_Reads_Direction = getDoubleProperty(KEY_Fisher_Thres_For_Reads_Direction,Fisher_Thres_For_Reads_Direction);
 		Fisher_Thres_For_SNV_Detection = getDoubleProperty(KEY_Fisher_Thres_For_SNV_Detection,Fisher_Thres_For_SNV_Detection);

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/KarkinosProp.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/KarkinosProp.java
@@ -174,7 +174,7 @@ public class KarkinosProp implements java.io.Serializable {
 		minPhredQual = getFloatProperty(KEY_minPhredQual,minPhredQual);
 		minMappability = getFloatProperty(KEY_minMappability,minMappability);
 		minEntropy = getFloatProperty(KEY_minEntropy,minEntropy);
-		//minMisMatchRate = getFloatProperty(KEY_minMisMatchRate,minMisMatchRate);
+		minMisMatchRate = getFloatProperty(KEY_minMisMatchRate,minMisMatchRate);
 
 		Fisher_Thres_For_Reads_Direction = getDoubleProperty(KEY_Fisher_Thres_For_Reads_Direction,Fisher_Thres_For_Reads_Direction);
 		Fisher_Thres_For_SNV_Detection = getDoubleProperty(KEY_Fisher_Thres_For_SNV_Detection,Fisher_Thres_For_SNV_Detection);

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -732,7 +732,9 @@ public class TumorGenotyper extends ReadWriteBase {
 				if (sam.getIntegerAttribute("NM")>=2) {
 
 					int terminalMismatch = TerminalMismatch.terminalMismatch(sam, tgr, KarkinosProp.extraReadTerminalCheckLen);
-					sam.setAttribute("TM",terminalMismatch);
+					if(terminalMismatch>=2){
+						continue;
+					}
 
 				}
 				if (qualityCheck(sam)) {

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -37,6 +37,8 @@ import jp.ac.utokyo.rcast.karkinos.annotation.loadsave.LoadSave;
 import jp.ac.utokyo.rcast.karkinos.annotation.loadsave.SaveBean;
 import jp.ac.utokyo.rcast.karkinos.filter.DefinedSites;
 import jp.ac.utokyo.rcast.karkinos.filter.FilterAnnotation;
+import jp.ac.utokyo.rcast.karkinos.filter.SoftClipExtention;
+import jp.ac.utokyo.rcast.karkinos.filter.TerminalMismatch;
 import jp.ac.utokyo.rcast.karkinos.graph.output.CNVVcf;
 import jp.ac.utokyo.rcast.karkinos.graph.output.FileOutPut;
 import jp.ac.utokyo.rcast.karkinos.graph.output.PdfReport;
@@ -673,6 +675,8 @@ public class TumorGenotyper extends ReadWriteBase {
 			ds = new DefinedSites(sites);
 			ds.load(sites,chrom);
 		}
+		//Ueda add 2020.12.18 load genome
+		tgr.readRef(chrom);
 
 		int n = 0;
 		for (Interval iv : ivlist) {
@@ -721,6 +725,16 @@ public class TumorGenotyper extends ReadWriteBase {
 				SAMRecord sam = tumorIte.next();
 				if (sam.getReadUnmappedFlag())
 					continue;
+				//add 2020/12/17 for FFPE anneling near repeat, H.Ueda
+				//extends softclip
+				SoftClipExtention.extendSoftclip(sam, tgr);
+				//count terminal mismatch
+				if (sam.getIntegerAttribute("NM")>=2) {
+
+					int terminalMismatch = TerminalMismatch.terminalMismatch(sam, tgr, KarkinosProp.extraReadTerminalCheckLen);
+					sam.setAttribute("TM",terminalMismatch);
+
+				}
 				if (qualityCheck(sam)) {
 					boolean onTarget = false;
 					OntagetInfo oi = dataset.setTumorCoverageInfo(sam);

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/FilterResult.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/FilterResult.java
@@ -84,6 +84,8 @@ public class FilterResult implements java.io.Serializable {
 	public static final int INFO_adjustLowdepth = 204;
 	public static final int INFO_minimumSupportReads = 205;
 
+	public static final int TERMINAL_MISMATCH = 35;
+
 	// bw.append("##FILTER=<ID=qf,Description=\"Quality below threshold\">");
 	// bw.append("##FILTER=<ID=bf,Description=\"Bayesian filterling\">");
 	// bw.append("##FILTER=<ID=snp,Description=\"dbSNP snp\">");
@@ -215,6 +217,11 @@ public class FilterResult implements java.io.Serializable {
 
 			// case High_normal_adjustedRatio:
 			// return "high_adj_ratio";
+
+			// add 2020/12/17 for FFPE anneling near repeat, H.Ueda
+		case TERMINAL_MISMATCH:
+			return "terminal_mismatch";
+
 		}
 
 		if (flg != 0) {

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
@@ -45,7 +45,6 @@ public class SoftClipExtention {
         CigarElement first = list.get(0);
         CigarElement second = list.get(1);
         int extraCheckLen = 15;
-
         if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
 
             int alignmentStart = sam.getAlignmentStart();
@@ -56,7 +55,7 @@ public class SoftClipExtention {
             for(int n=alignmentStart;n<=alignmentStart+extraCheckLen;n++){
                 //
                 char refNuc = tgr._getGenomeNuc(n,true);
-                int idx = sam.getReadPositionAtReferencePosition(n)-1+first.getLength();
+                int idx = sam.getReadPositionAtReferencePosition(n)-1;
                 if(idx>=0 && idx<sam.getReadLength()){
                     char readNuc = sam.getReadString().charAt(idx);
                     if(!equalnuc(refNuc,readNuc)){
@@ -81,8 +80,6 @@ public class SoftClipExtention {
             }
             //
             if(clipidx>0){
-
-                //
                 Cigar cgn = new Cigar();
                 CigarElement sc = new CigarElement(clipidx+1,CigarOperator.S);
                 cgn.add(sc);
@@ -92,7 +89,7 @@ public class SoftClipExtention {
                     cgn.add(list.get(m));
                 }
                 sam.setCigar(cgn);
-                int alstart = sam.getStart()+clipidx+1;
+                int alstart = sam.getStart()+(clipidx+1-first.getLength());
                 sam.setAlignmentStart(alstart);
                 int  nm = sam.getIntegerAttribute("NM");
                 nm = nm - miscount;
@@ -108,11 +105,6 @@ public class SoftClipExtention {
         CigarElement second = list.get(size-2);
         int extraCheckLen = 15;
 
-        CigarElement leftmost = sam.getCigar().getCigarElements().get(0);
-        int scidx = 0;
-        if(isClipped(leftmost)){
-            scidx = leftmost.getLength();
-        }
         if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
 
             int alignmentEnd = sam.getAlignmentEnd();
@@ -123,7 +115,7 @@ public class SoftClipExtention {
             for(int n=alignmentEnd;n>=alignmentEnd-extraCheckLen;n--){
                 //
                 char refNuc = tgr._getGenomeNuc(n,true);
-                int idx = sam.getReadPositionAtReferencePosition(n)-1+scidx;
+                int idx = sam.getReadPositionAtReferencePosition(n)-1;
                 if(idx>=0 && idx<sam.getReadLength()){
                     char readNuc = sam.getReadString().charAt(idx);
                     if(!equalnuc(refNuc,readNuc)){

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
@@ -44,7 +44,8 @@ public class SoftClipExtention {
         List<CigarElement> list = sam.getCigar().getCigarElements();
         CigarElement first = list.get(0);
         CigarElement second = list.get(1);
-        int extraCheckLen = 15;
+        int extraCheckLen = 20;
+
         if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
 
             int alignmentStart = sam.getAlignmentStart();
@@ -63,15 +64,15 @@ public class SoftClipExtention {
                         lastidx = idx;
                     }
                 }
-                if(m==4){
+                if(m==9){
                     if(miscount>0){
                         clipidx = lastidx;
                     }
-                }else if(m==9){
+                }else if(m==14){
                     if(miscount>1){
                         clipidx = lastidx;
                     }
-                }else if(m==14){
+                }else if(m==19){
                     if(miscount>2){
                         clipidx = lastidx;
                     }
@@ -103,7 +104,7 @@ public class SoftClipExtention {
         int size = list.size();
         CigarElement first = list.get(size-1);
         CigarElement second = list.get(size-2);
-        int extraCheckLen = 15;
+        int extraCheckLen = 20;
 
         if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
 
@@ -123,15 +124,15 @@ public class SoftClipExtention {
                         lastidx = idx;
                     }
                 }
-                if(m==4){
+                if(m==9){
                     if(miscount>0){
                         clipidx = lastidx;
                     }
-                }else if(m==9){
+                }else if(m==14){
                     if(miscount>1){
                         clipidx = lastidx;
                     }
-                }else if(m==14){
+                }else if(m==19){
                     if(miscount>2){
                         clipidx = lastidx;
                     }
@@ -145,7 +146,6 @@ public class SoftClipExtention {
                 for(m=0;m<list.size()-2;m++){
                     cgn.add(list.get(m));
                 }
-
                 int sclen = sam.getReadLength()-(clipidx+1);
                 int mlen = second.getLength() - (sclen - first.getLength());
                 CigarElement mc = new CigarElement(mlen,CigarOperator.M);

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
@@ -1,0 +1,181 @@
+/*
+Copyright Hiroki Ueda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package jp.ac.utokyo.rcast.karkinos.filter;
+
+import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SoftClipExtention {
+
+    //add 2020/12/17 for FFPE anneling near repeat, extends soft clipping
+    public static void extendSoftclip(SAMRecord sam, TwoBitGenomeReader tgr) {
+        try {
+            if(sam.getCigar().getCigarElements().size()>=2) {
+                leftExtention(sam, tgr);
+                rightExtention(sam, tgr);
+            }
+
+        }catch(Exception ex){
+            //could not extend soft clips
+            ex.printStackTrace();
+        }
+    }
+
+    private static void leftExtention(SAMRecord sam, TwoBitGenomeReader tgr) {
+        List<CigarElement> list = sam.getCigar().getCigarElements();
+        CigarElement first = list.get(0);
+        CigarElement second = list.get(1);
+        int extraCheckLen = 15;
+
+        if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
+
+            int alignmentStart = sam.getAlignmentStart();
+            int miscount = 0;
+            int lastidx = 0;
+            int m = 0;
+            int clipidx = 0;
+            for(int n=alignmentStart;n<=alignmentStart+extraCheckLen;n++){
+                //
+                char refNuc = tgr._getGenomeNuc(n,true);
+                int idx = sam.getReadPositionAtReferencePosition(n)-1;
+                if(idx>=0 && idx<sam.getReadLength()){
+                    char readNuc = sam.getReadString().charAt(idx);
+                    if(!equalnuc(refNuc,readNuc)){
+                        miscount++;
+                        lastidx = idx;
+                    }
+                }
+                if(m==4){
+                    if(miscount>0){
+                        clipidx = lastidx;
+                    }
+                }else if(m==9){
+                    if(miscount>1){
+                        clipidx = lastidx;
+                    }
+                }else if(m==14){
+                    if(miscount>2){
+                        clipidx = lastidx;
+                    }
+                }
+                m++;
+            }
+
+            //
+            if(clipidx>0){
+
+                //
+                Cigar cgn = new Cigar();
+                CigarElement sc = new CigarElement(clipidx+1,CigarOperator.S);
+                cgn.add(sc);
+                CigarElement mc = new CigarElement((first.getLength()+second.getLength())-(clipidx+1),CigarOperator.M);
+                cgn.add(mc);
+                for(m=2; m<list.size(); m++){
+                    cgn.add(list.get(m));
+                }
+                sam.setCigar(cgn);
+                int alstart = sam.getStart()+clipidx+1;
+                sam.setAlignmentStart(alstart);
+                int  nm = sam.getIntegerAttribute("NM");
+                nm = nm - miscount;
+                sam.setAttribute("NM",nm);
+            }
+        }
+    }
+
+    private static void rightExtention(SAMRecord sam,TwoBitGenomeReader tgr) {
+        List<CigarElement> list = sam.getCigar().getCigarElements();
+        int size = list.size();
+        CigarElement first = list.get(size-1);
+        CigarElement second = list.get(size-2);
+        int extraCheckLen = 15;
+
+        if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
+
+            int alignmentEnd = sam.getAlignmentEnd();
+            int miscount = 0;
+            int lastidx = 0;
+            int m = 0;
+            int clipidx = 0;
+
+            for(int n=alignmentEnd;n>=alignmentEnd-extraCheckLen;n--){
+                //
+                char refNuc = tgr._getGenomeNuc(n,true);
+                int idx = sam.getReadPositionAtReferencePosition(n)-1;
+                if(idx>=0 && idx<sam.getReadLength()){
+                    char readNuc = sam.getReadString().charAt(idx);
+                    if(!equalnuc(refNuc,readNuc)){
+                        miscount++;
+                        lastidx = idx;
+                    }
+                }
+                if(m==4){
+                    if(miscount>0){
+                        clipidx = lastidx;
+                    }
+                }else if(m==9){
+                    if(miscount>1){
+                        clipidx = lastidx;
+                    }
+                }else if(m==14){
+                    if(miscount>2){
+                        clipidx = lastidx;
+                    }
+                }
+                m++;
+            }
+
+            //
+            if(clipidx>0){
+                //
+                Cigar cgn = new Cigar();
+                for(m=0;m<list.size()-2;m++){
+                    cgn.add(list.get(m));
+                }
+
+                int sclen = sam.getReadLength()-(clipidx+1);
+                int mlen = second.getLength() - (sclen - first.getLength());
+                CigarElement mc = new CigarElement(mlen,CigarOperator.M);
+                CigarElement sc = new CigarElement(sclen,CigarOperator.S);
+                cgn.add(mc);
+                cgn.add(sc);
+                sam.setCigar(cgn);
+                int  nm = sam.getIntegerAttribute("NM");
+                nm = nm - miscount;
+                sam.setAttribute("NM",nm);
+            }
+        }
+    }
+
+    private static boolean equalnuc(char refNuc,char readNuc) {
+        return Character.toUpperCase(refNuc) == Character.toUpperCase(readNuc);
+    }
+
+    private static boolean isClipped(CigarElement ce) {
+        return ce.getOperator().equals(CigarOperator.S);
+    }
+
+    private static boolean isM(CigarElement ce) {
+        return ce.getOperator().equals(CigarOperator.M);
+    }
+}

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SoftClipExtention.java
@@ -34,7 +34,6 @@ public class SoftClipExtention {
                 leftExtention(sam, tgr);
                 rightExtention(sam, tgr);
             }
-
         }catch(Exception ex){
             //could not extend soft clips
             ex.printStackTrace();
@@ -57,7 +56,7 @@ public class SoftClipExtention {
             for(int n=alignmentStart;n<=alignmentStart+extraCheckLen;n++){
                 //
                 char refNuc = tgr._getGenomeNuc(n,true);
-                int idx = sam.getReadPositionAtReferencePosition(n)-1;
+                int idx = sam.getReadPositionAtReferencePosition(n)-1+first.getLength();
                 if(idx>=0 && idx<sam.getReadLength()){
                     char readNuc = sam.getReadString().charAt(idx);
                     if(!equalnuc(refNuc,readNuc)){
@@ -80,7 +79,6 @@ public class SoftClipExtention {
                 }
                 m++;
             }
-
             //
             if(clipidx>0){
 
@@ -90,7 +88,7 @@ public class SoftClipExtention {
                 cgn.add(sc);
                 CigarElement mc = new CigarElement((first.getLength()+second.getLength())-(clipidx+1),CigarOperator.M);
                 cgn.add(mc);
-                for(m=2; m<list.size(); m++){
+                for(m=2;m<list.size();m++){
                     cgn.add(list.get(m));
                 }
                 sam.setCigar(cgn);
@@ -103,13 +101,18 @@ public class SoftClipExtention {
         }
     }
 
-    private static void rightExtention(SAMRecord sam,TwoBitGenomeReader tgr) {
+    private static void rightExtention(SAMRecord sam, TwoBitGenomeReader tgr) {
         List<CigarElement> list = sam.getCigar().getCigarElements();
         int size = list.size();
         CigarElement first = list.get(size-1);
         CigarElement second = list.get(size-2);
         int extraCheckLen = 15;
 
+        CigarElement leftmost = sam.getCigar().getCigarElements().get(0);
+        int scidx = 0;
+        if(isClipped(leftmost)){
+            scidx = leftmost.getLength();
+        }
         if(isClipped(first)&&isM(second)&&second.getLength()>extraCheckLen){
 
             int alignmentEnd = sam.getAlignmentEnd();
@@ -117,11 +120,10 @@ public class SoftClipExtention {
             int lastidx = 0;
             int m = 0;
             int clipidx = 0;
-
             for(int n=alignmentEnd;n>=alignmentEnd-extraCheckLen;n--){
                 //
                 char refNuc = tgr._getGenomeNuc(n,true);
-                int idx = sam.getReadPositionAtReferencePosition(n)-1;
+                int idx = sam.getReadPositionAtReferencePosition(n)-1+scidx;
                 if(idx>=0 && idx<sam.getReadLength()){
                     char readNuc = sam.getReadString().charAt(idx);
                     if(!equalnuc(refNuc,readNuc)){
@@ -144,7 +146,6 @@ public class SoftClipExtention {
                 }
                 m++;
             }
-
             //
             if(clipidx>0){
                 //

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
@@ -15,6 +15,24 @@ limitations under the License.
  */
 package jp.ac.utokyo.rcast.karkinos.filter;
 
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.CONTAIN_Reccurent_MISMATCH;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.INFO_AllelicInfoAvailable;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.INFO_SUPPORTED_BY_ONEDirection;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.LOW_PROPER;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.MutationAtSameCycle;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.NEARINDEL;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.NOISE_IN_NORMAL;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.READSENDSONLY;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.SUPPORTED_BY_ONEDirection;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.SUPPORTED_READSNG;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.TNQualityDiff;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.TooManyMismatchReads;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.noStrandSpecific;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.softClip;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.INFO_ffpe;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.INFO_oxoG;
+import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.TERMINAL_MISMATCH;
+
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMFileReader;
@@ -45,8 +63,6 @@ import jp.ac.utokyo.rcast.karkinos.utils.ReadWriteBase;
 import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
 
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
-
-import static jp.ac.utokyo.rcast.karkinos.filter.FilterResult.*;
 
 public class SupportReadsCheck extends ReadWriteBase {
 	String bam;
@@ -359,14 +375,14 @@ public class SupportReadsCheck extends ReadWriteBase {
 		if (mismatchRate > KarkinosProp.minMisMatchRate) {
 			filter.add(TooManyMismatchReads);
 		}
-		
+
 		//For todai top SNV
 		if (supportreads != null && supportreads.size() <= 5) {
 			float readratiothres = KarkinosProp.falseReadratio;
 			if ((oxoGCand)||(ffpeCand)) {
 				readratiothres = KarkinosProp.falseReadratio2;
 			}
-			
+
 			float falseReadRatio = getFalseReadRate(supportreads, pos, KarkinosProp.falseReadMismatchratio);
 			if (falseReadRatio >= readratiothres) {
 				filter.add(TooManyMismatchReads);
@@ -521,13 +537,13 @@ public class SupportReadsCheck extends ReadWriteBase {
 		// // regrec = true;
 		// // }
 		// }
-		if (recnt >= 2) {
+		if (recnt >= 4) {
 			filter.add(CONTAIN_Reccurent_MISMATCH);
 		}
-		if (diffrecnt >= 1) {
+		if (diffrecnt >= 3) {
 			filter.add(CONTAIN_Reccurent_MISMATCH);
 		}
-		if (diffcountneighbor >= 8) {
+		if (diffcountneighbor >= 10) {
 			filter.add(CONTAIN_Reccurent_MISMATCH);
 		}
 		// change value 2013.07.03

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
@@ -24,16 +24,13 @@ import htsjdk.samtools.SAMRecord;
 
 import java.util.List;
 
+
 public class TerminalMismatch {
+
     //add 2020/12/17 for FFPE anneling near repeat, extends soft clipping
     public static int terminalMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
         try {
-            //does not check Indel read
-            if(containIndel(sam)){
-                return 0;
-            }
             return Math.max(leftMismatch(sam,tgr,extraCheckLen),rightMismatch(sam,tgr,extraCheckLen));
-
         }catch(Exception ex){
             //
             ex.printStackTrace();
@@ -41,7 +38,7 @@ public class TerminalMismatch {
         return 0;
     }
 
-    private static boolean containIndel(SAMRecord sam){
+    private static boolean containIndel(SAMRecord sam) {
         List<CigarElement> l = sam.getCigar().getCigarElements();
         for(CigarElement ce: l){
             if(ce.getOperator().equals(CigarOperator.I))return true;
@@ -53,15 +50,10 @@ public class TerminalMismatch {
     private static int leftMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
         int alignmentStart = sam.getAlignmentStart();
         int miscount = 0;
-        CigarElement first = sam.getCigar().getCigarElements().get(0);
-        int scidx = 0;
-        if(isClipped(first)){
-            scidx = first.getLength();
-        }
         for(int n=alignmentStart;n<=alignmentStart+extraCheckLen;n++){
             //
             char refNuc = tgr._getGenomeNuc(n,true);
-            int idx = sam.getReadPositionAtReferencePosition(n)-1+scidx;
+            int idx = sam.getReadPositionAtReferencePosition(n)-1;
             if(idx>=0 && idx<sam.getReadLength()){
                 char readNuc = sam.getReadString().charAt(idx);
                 if(!equalnuc(refNuc,readNuc)){
@@ -75,15 +67,10 @@ public class TerminalMismatch {
     private static int rightMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
         int alignmentEnd = sam.getAlignmentEnd();
         int miscount = 0;
-        CigarElement first = sam.getCigar().getCigarElements().get(0);
-        int scidx = 0;
-        if(isClipped(first)){
-            scidx = first.getLength();
-        }
         for(int n=alignmentEnd;n>=alignmentEnd-extraCheckLen;n--){
             //
             char refNuc = tgr._getGenomeNuc(n,true);
-            int idx = sam.getReadPositionAtReferencePosition(n)-1+scidx;
+            int idx = sam.getReadPositionAtReferencePosition(n)-1;
             if(idx>=0 && idx<sam.getReadLength()){
                 char readNuc = sam.getReadString().charAt(idx);
                 if(!equalnuc(refNuc,readNuc)){
@@ -94,7 +81,7 @@ public class TerminalMismatch {
         return miscount;
     }
 
-    private static boolean equalnuc(char refNuc,char readNuc) {
+    private static boolean equalnuc(char refNuc, char readNuc) {
         return Character.toUpperCase(refNuc) == Character.toUpperCase(readNuc);
     }
 

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
@@ -1,0 +1,86 @@
+/*
+Copyright Hiroki Ueda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package jp.ac.utokyo.rcast.karkinos.filter;
+
+import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMRecord;
+
+import java.util.List;
+
+
+public class TerminalMismatch {
+
+    //add 2020/12/17 for FFPE anneling near repeat, extends soft clipping
+    public static int terminalMismatch(SAMRecord sam, TwoBitGenomeReader tgr,int extraCheckLen) {
+        try {
+            return Math.max(leftMismatch(sam,tgr,extraCheckLen),rightMismatch(sam,tgr,extraCheckLen));
+        }catch(Exception ex){
+            //could not extend soft clips
+            ex.printStackTrace();
+        }
+        return 0;
+    }
+
+    private static int leftMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
+        int alignmentStart = sam.getAlignmentStart();
+        int miscount = 0;
+
+        for(int n=alignmentStart;n<=alignmentStart+extraCheckLen;n++){
+            //
+            char refNuc = tgr._getGenomeNuc(n,true);
+            int idx = sam.getReadPositionAtReferencePosition(n)-1;
+            if(idx>=0 && idx<sam.getReadLength()){
+                char readNuc = sam.getReadString().charAt(idx);
+                if(!equalnuc(refNuc,readNuc)){
+                    miscount++;
+                }
+            }
+        }
+
+        return miscount;
+    }
+
+    private static int rightMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
+        int alignmentEnd = sam.getAlignmentEnd();
+        int miscount = 0;
+
+        for(int n=alignmentEnd;n>=alignmentEnd-extraCheckLen;n--){
+            //
+            char refNuc = tgr._getGenomeNuc(n,true);
+            int idx = sam.getReadPositionAtReferencePosition(n)-1;
+            if(idx>=0 && idx<sam.getReadLength()){
+                char readNuc = sam.getReadString().charAt(idx);
+                if(!equalnuc(refNuc,readNuc)){
+                    miscount++;
+                }
+            }
+        }
+
+        return miscount;
+    }
+
+    private static boolean equalnuc(char refNuc,char readNuc) {
+        return Character.toUpperCase(refNuc) == Character.toUpperCase(readNuc);
+    }
+
+    private static boolean isClipped(CigarElement ce){
+        return ce.getOperator().equals(CigarOperator.S);
+    }
+}


### PR DESCRIPTION
This PR adds two filters as follows.

**1. Soft-clipping expansion**

If there are mismatches more than X in the inner Y bases of soft-clipped ends, it extends the soft-clip to the innermost mismatch position. It doesn't update alignments in the bam file.

**2. Double-ended mismatch**

If there are more than X mismatch bases in each of the Y bases at both ends, it marks reads as NG (terminal mismatch read). The NG reads will no longer be used for variant calls.

You can change the behavior of the above filter by Karkinos's property file.

e.g. 

```
extraReadTerminalCheckLen=20
extraReadTerminalMismatchThres=2
```