### PR TITLE
Loosen the filter condition of INDEL in a normal sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ jacoco {
 }
 
 group = 'karkinos'
-version = '2.0.6-SNAPSHOT'
+version = '2.1.0-SNAPSHOT'
 
 description = """"""
 

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
@@ -169,7 +169,7 @@ public class PileUP implements java.io.Serializable {
 				snvHolder.setNormal(normal2);
 				snvHolder.setTumor(tumor2);
 				int iflg = NormalINDEL;
-				if (tumor.indel && normal.indel) {
+			    if (bothIndel(normal,tumor,normal2,tumor2)) {
 					iflg = BothINDEL;
 				} else if (tumor.indel) {
 					iflg = TumorINDEL;
@@ -289,7 +289,7 @@ public class PileUP implements java.io.Serializable {
 		boolean isFirst = false;
 		int retindex = startidx;
 		int lowqual = 0;
-		int ontarget = 0; 
+		int ontarget = 0;
 
 		for (int n = startidx; n < samList.size(); n++) {
 			SamHolder sh = samList.get(n);
@@ -471,5 +471,15 @@ public class PileUP implements java.io.Serializable {
 			end = start + sam.getReadLength() - 1;
 		}
 		return pos >= start && pos <= end;
+	}
+
+	private static boolean bothIndel(PileUPResult normal,PileUPResult tumor,PileUPResult normal2,PileUPResult tumor2){
+		if(tumor.indel && normal.indel){
+			if(tumor2.getRatio() > 0.1 && normal2.getRatio() < 0.01){
+				return false;
+			}
+			return true;
+		}
+		return false;
 	}
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
@@ -474,8 +474,22 @@ public class PileUP implements java.io.Serializable {
 	}
 
 	private static boolean bothIndel(PileUPResult normal,PileUPResult tumor,PileUPResult normal2,PileUPResult tumor2){
+
 		if(tumor.indel && normal.indel){
-			if(tumor2.getRatio() > 0.1 && normal2.getRatio() < 0.01){
+			if(normal2.getAltCnt()>=3){
+				return true;
+			}
+			if(normal2.getAltCnt()==1 && normal2.getRatio() < 0.005){
+				if(normal2.insersion != tumor2.insersion){
+					return true;
+				}
+			}
+			if(normal2.getRatio()==0){
+				//should not come here
+				return false;
+			}
+			double r = tumor2.getRatio()/normal2.getRatio();
+			if(r >  20.0 && normal2.getRatio() < 0.005 && tumor2.getAltCnt()>=20){
 				return false;
 			}
 			return true;

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/PileUP.java
@@ -475,25 +475,25 @@ public class PileUP implements java.io.Serializable {
 
 	private static boolean bothIndel(PileUPResult normal,PileUPResult tumor,PileUPResult normal2,PileUPResult tumor2){
 
-		if(tumor.indel && normal.indel){
-			if(normal2.getAltCnt()>=3){
-				return true;
-			}
-			if(normal2.getAltCnt()==1 && normal2.getRatio() < 0.005){
-				if(normal2.insersion != tumor2.insersion){
-					return true;
-				}
-			}
-			if(normal2.getRatio()==0){
-				//should not come here
-				return false;
+		if(tumor.indel && normal.indel && normal2.getRatio()>0){
+			boolean bothIndel = true;
+			if((normal2.getAltCnt()==1)
+					&& (normal2.getRatio() < 0.005)
+					&& (normal2.insersion != tumor2.insersion)){
+
+				bothIndel =  false;
+
 			}
 			double r = tumor2.getRatio()/normal2.getRatio();
-			if(r >  20.0 && normal2.getRatio() < 0.005 && tumor2.getAltCnt()>=20){
-				return false;
+			if((normal2.getAltCnt()<=2)
+					&& (tumor2.getAltCnt()>=20)
+					&&  (r >  20.0)
+					&& (normal2.getRatio() < 0.005)){
+				bothIndel = false;
 			}
-			return true;
+			return bothIndel;
+		}else {
+			return false;
 		}
-		return false;
 	}
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -724,9 +724,6 @@ public class TumorGenotyper extends ReadWriteBase {
 			int readslent = 0;
 			while (tumorIte.hasNext()) {
 				SAMRecord sam = tumorIte.next();
-				if(SamUtils.lowmap(sam)) {
-					continue;
-				}
 				//add 2020/12/17 for FFPE anneling near repeat, H.Ueda
 				//extends softclip
 				SoftClipExtention.extendSoftclip(sam, tgr);
@@ -781,6 +778,6 @@ public class TumorGenotyper extends ReadWriteBase {
 	}
 
 	private boolean qualityCheck(SAMRecord sam) {
-		return true;
+		return !SamUtils.lowmap(sam);
 	}
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -728,7 +728,7 @@ public class TumorGenotyper extends ReadWriteBase {
 				//extends softclip
 				SoftClipExtention.extendSoftclip(sam, tgr);
 				//count terminal mismatch
-				if (sam.getIntegerAttribute("NM")>=2) {
+				if (sam.getIntegerAttribute("NM") != null && sam.getIntegerAttribute("NM") >= 2) {
 
 					int terminalMismatch = TerminalMismatch.terminalMismatch(sam, tgr, KarkinosProp.extraReadTerminalCheckLen);
 					if(terminalMismatch>=2){

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -47,7 +47,14 @@ import jp.ac.utokyo.rcast.karkinos.hmm.CountCNV;
 import jp.ac.utokyo.rcast.karkinos.hmm.HMMCNVAnalysisFromEM;
 import jp.ac.utokyo.rcast.karkinos.readssummary.GeneExons;
 import jp.ac.utokyo.rcast.karkinos.readssummary.ReadsSummary;
-import jp.ac.utokyo.rcast.karkinos.utils.*;
+import jp.ac.utokyo.rcast.karkinos.utils.CorrelVaridate;
+import jp.ac.utokyo.rcast.karkinos.utils.GeneEachCNV;
+import jp.ac.utokyo.rcast.karkinos.utils.Interval;
+import jp.ac.utokyo.rcast.karkinos.utils.ListUtils;
+import jp.ac.utokyo.rcast.karkinos.utils.OptionComparator;
+import jp.ac.utokyo.rcast.karkinos.utils.ReadWriteBase;
+import jp.ac.utokyo.rcast.karkinos.utils.SamUtils;
+import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
 import jp.ac.utokyo.rcast.karkinos.wavelet.EMMethod;
 import jp.ac.utokyo.rcast.karkinos.wavelet.GCParcentAdjust;
 import jp.ac.utokyo.rcast.karkinos.wavelet.PeaksInfo;
@@ -129,7 +136,7 @@ public class TumorGenotyper extends ReadWriteBase {
 
 		optionlist.add(getOption("startend", "startend", true,
 				"start-end position", false));
-		
+
 		optionlist.add(getOption("rs", "readsStats", true,
 				"optional,reads stats files(normal,tumor)", false));
 
@@ -141,8 +148,8 @@ public class TumorGenotyper extends ReadWriteBase {
 
 		optionlist.add(getOption("nopdf", "nopdf", false,
 				"no graphic summary pdf output", false));
-		
-		
+
+
 		optionlist.add(getOption("sites", "pileupsites", true,
 				"disgnated pileup sites", false));
 
@@ -321,7 +328,7 @@ public class TumorGenotyper extends ReadWriteBase {
 					// }
 				}
 			}
-			outputsave = outobjdir + targetChr + "_" + id + "_"+ startends 
+			outputsave = outobjdir + targetChr + "_" + id + "_"+ startends
 					+ "_saveobj.obj";
 		}
 
@@ -708,7 +715,7 @@ public class TumorGenotyper extends ReadWriteBase {
 				normalcnt++;
 				readslenn = sam.getReadLength();
 			}
-			
+
 			System.out.println(iv.getStr() + " normal reads " + normalcnt
 					+ " has been reads");
 
@@ -740,7 +747,7 @@ public class TumorGenotyper extends ReadWriteBase {
 					}
 					boolean dupli = sam.getDuplicateReadFlag();
 					if (onTarget && !dupli) {
-						
+
 						SamHolder sh = new SamHolder();
 						sh.setSam(sam);
 						sh.setOi(oi);
@@ -773,5 +780,7 @@ public class TumorGenotyper extends ReadWriteBase {
 		}
 	}
 
-
+	private boolean qualityCheck(SAMRecord sam) {
+		return true;
+	}
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -47,13 +47,7 @@ import jp.ac.utokyo.rcast.karkinos.hmm.CountCNV;
 import jp.ac.utokyo.rcast.karkinos.hmm.HMMCNVAnalysisFromEM;
 import jp.ac.utokyo.rcast.karkinos.readssummary.GeneExons;
 import jp.ac.utokyo.rcast.karkinos.readssummary.ReadsSummary;
-import jp.ac.utokyo.rcast.karkinos.utils.CorrelVaridate;
-import jp.ac.utokyo.rcast.karkinos.utils.GeneEachCNV;
-import jp.ac.utokyo.rcast.karkinos.utils.Interval;
-import jp.ac.utokyo.rcast.karkinos.utils.ListUtils;
-import jp.ac.utokyo.rcast.karkinos.utils.OptionComparator;
-import jp.ac.utokyo.rcast.karkinos.utils.ReadWriteBase;
-import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
+import jp.ac.utokyo.rcast.karkinos.utils.*;
 import jp.ac.utokyo.rcast.karkinos.wavelet.EMMethod;
 import jp.ac.utokyo.rcast.karkinos.wavelet.GCParcentAdjust;
 import jp.ac.utokyo.rcast.karkinos.wavelet.PeaksInfo;
@@ -725,6 +719,9 @@ public class TumorGenotyper extends ReadWriteBase {
 				SAMRecord sam = tumorIte.next();
 				if (sam.getReadUnmappedFlag())
 					continue;
+				if(qualityCheck(sam)==false) {
+					continue;
+				}
 				//add 2020/12/17 for FFPE anneling near repeat, H.Ueda
 				//extends softclip
 				SoftClipExtention.extendSoftclip(sam, tgr);
@@ -780,6 +777,7 @@ public class TumorGenotyper extends ReadWriteBase {
 
 	private boolean qualityCheck(SAMRecord sam) {
 		// TODO Auto-generated method stub
-		return true;
+		boolean lowmap = SamUtils.lowmap(sam);
+		return !lowmap;
 	}
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -717,9 +717,7 @@ public class TumorGenotyper extends ReadWriteBase {
 			int readslent = 0;
 			while (tumorIte.hasNext()) {
 				SAMRecord sam = tumorIte.next();
-				if (sam.getReadUnmappedFlag())
-					continue;
-				if(qualityCheck(sam)==false) {
+				if(SamUtils.lowmap(sam)) {
 					continue;
 				}
 				//add 2020/12/17 for FFPE anneling near repeat, H.Ueda
@@ -775,9 +773,5 @@ public class TumorGenotyper extends ReadWriteBase {
 		}
 	}
 
-	private boolean qualityCheck(SAMRecord sam) {
-		// TODO Auto-generated method stub
-		boolean lowmap = SamUtils.lowmap(sam);
-		return !lowmap;
-	}
+
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/FilterAnnotation.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/FilterAnnotation.java
@@ -210,7 +210,7 @@ public class FilterAnnotation {
 			boolean indelinrepeat = false;
 			int start = pos + 1;
 			int end = pos + 10;
-			
+
 			int dellenn = 0;
 			String del="";
 			if (isindel) {
@@ -221,7 +221,7 @@ public class FilterAnnotation {
 						start = pos + dellenn;
 						end = pos + dellenn + 10;
 						del = tgr.getGenomicSeq(chrom, pos+1,pos+dellenn, true);
-						
+
 					}
 				} catch (Exception ex) {
 				}
@@ -254,6 +254,10 @@ public class FilterAnnotation {
 				sseq = after10;
 			}
 
+			if (isindel) {
+				seqEntropy = 100;
+			}
+
 			// high isoform
 			boolean highisoform = false;
 			if (ge != null) {
@@ -283,7 +287,7 @@ public class FilterAnnotation {
 			}
 			// 20170317 todai
 			if(indelinrepeat){
-				
+
 				if((normalTotal<snv.getTumor().getTotalcnt()*0.5) && (normalTotal<50) && snv.getTumor().getAltCnt()<=12){
 				  supportReadsFlgs.add(FilterResult.Low_complexty);
 				}

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
@@ -60,6 +60,7 @@ import jp.ac.utokyo.rcast.karkinos.exec.PileUPResult;
 import jp.ac.utokyo.rcast.karkinos.exec.PileUPResult.Counter;
 import jp.ac.utokyo.rcast.karkinos.utils.OddRatioCalculator;
 import jp.ac.utokyo.rcast.karkinos.utils.ReadWriteBase;
+import jp.ac.utokyo.rcast.karkinos.utils.SamUtils;
 import jp.ac.utokyo.rcast.karkinos.utils.TwoBitGenomeReader;
 
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
@@ -125,6 +126,12 @@ public class SupportReadsCheck extends ReadWriteBase {
 
 		while (ite.hasNext()) {
 			SAMRecord sam = ite.next();
+			if(SamUtils.lowmap(sam)){
+				continue;
+			}
+			//add 2020/12/17 for FFPE anneling near repeat, H.Ueda
+			//extends softclip
+			SoftClipExtention.extendSoftclip(sam, tgr);
 			// System.out.println(sam.getReadString());
 			allreads.add(sam);
 			int[] reta = containTargetMutation(pos, pileUPResult, sam, pileupFlg);

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/TerminalMismatch.java
@@ -61,7 +61,27 @@ public class TerminalMismatch {
                 }
             }
         }
-        return miscount;
+        //add Indel event
+        int n = 0;
+        int cntIndel = 0;
+        for(CigarElement cg:sam.getCigar().getCigarElements()){
+
+            if(cg.getOperator().equals(CigarOperator.S)){
+                continue;
+            }
+            if(cg.getOperator().equals(CigarOperator.M)){
+                n=n+cg.getLength();
+            }
+            if(n>=extraCheckLen){
+                break;
+            }
+            if(cg.getOperator().equals(CigarOperator.I) || cg.getOperator().equals(CigarOperator.D)){
+                cntIndel++;
+            }
+
+        }
+
+        return miscount+cntIndel;
     }
 
     private static int rightMismatch(SAMRecord sam, TwoBitGenomeReader tgr, int extraCheckLen) {
@@ -78,7 +98,28 @@ public class TerminalMismatch {
                 }
             }
         }
-        return miscount;
+        //add Indel event ueda 2021.1.14
+        int n = 0;
+        int cntIndel = 0;
+        List<CigarElement> cel = sam.getCigar().getCigarElements();
+        for(int m = cel.size()-1;m>=0;m--){
+
+            CigarElement cg = cel.get(m);
+            if(cg.getOperator().equals(CigarOperator.S)){
+                continue;
+            }
+            if(cg.getOperator().equals(CigarOperator.M)){
+                n=n+cg.getLength();
+            }
+            if(n>=extraCheckLen){
+                break;
+            }
+            if(cg.getOperator().equals(CigarOperator.I) || cg.getOperator().equals(CigarOperator.D)){
+                cntIndel++;
+            }
+
+        }
+        return miscount+cntIndel;
     }
 
     private static boolean equalnuc(char refNuc, char readNuc) {

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/DataHolder.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/DataHolder.java
@@ -1,3 +1,18 @@
+/*
+Copyright Hiroki Ueda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package jp.ac.utokyo.rcast.karkinos.utils;
 
 import java.util.ArrayList;

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/GeneEachCNV.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/GeneEachCNV.java
@@ -1,3 +1,18 @@
+/*
+Copyright Hiroki Ueda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package jp.ac.utokyo.rcast.karkinos.utils;
 
 import java.util.List;

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
@@ -1,5 +1,19 @@
-package jp.ac.utokyo.rcast.karkinos.utils;
+/*
+Copyright Hiroki Ueda
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package jp.ac.utokyo.rcast.karkinos.utils;
 
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
@@ -10,11 +24,10 @@ public class SamUtils {
     public static boolean lowmap(SAMRecord sam) {
 
         if(sam.getReadUnmappedFlag()
-         || (sam.getMappingQuality() <= 3)
-         || sam.getNotPrimaryAlignmentFlag()){
+           || (sam.getMappingQuality() <= 3)
+           || sam.getNotPrimaryAlignmentFlag()){
             return true;
         }
-
 
         int seqlen = sam.getReadLength();
         int match = 0;
@@ -34,7 +47,6 @@ public class SamUtils {
             if (ce.getOperator() == CigarOperator.S) {
                 sclen = sclen + ce.getLength();
             }
-
         }
 
         if (indelcnt >= 3)return true;
@@ -55,7 +67,4 @@ public class SamUtils {
 
         return false;
     }
-
-
-
 }

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
@@ -9,13 +9,12 @@ public class SamUtils {
 
     public static boolean lowmap(SAMRecord sam) {
 
-        //System.out.println("mq"+sam.getMappingQuality());
-        if (sam.getMappingQuality() <= 3) {
+        if(sam.getReadUnmappedFlag()
+         || (sam.getMappingQuality() <= 3)
+         || sam.getNotPrimaryAlignmentFlag()){
             return true;
         }
-        if(sam.getNotPrimaryAlignmentFlag()){
-            return true;
-        }
+
 
         int seqlen = sam.getReadLength();
         int match = 0;

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/SamUtils.java
@@ -1,0 +1,62 @@
+package jp.ac.utokyo.rcast.karkinos.utils;
+
+
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMRecord;
+
+public class SamUtils {
+
+    public static boolean lowmap(SAMRecord sam) {
+
+        //System.out.println("mq"+sam.getMappingQuality());
+        if (sam.getMappingQuality() <= 3) {
+            return true;
+        }
+        if(sam.getNotPrimaryAlignmentFlag()){
+            return true;
+        }
+
+        int seqlen = sam.getReadLength();
+        int match = 0;
+        int indelcnt = 0;
+        int indellen = 0;
+        int sclen = 0;
+        for (CigarElement ce : sam.getCigar().getCigarElements()) {
+            // if(ce.getOperator() == CigarOperator.S)return true;
+            if (ce.getOperator() == CigarOperator.I) {
+                indelcnt++;
+                indellen = indellen + ce.getLength();
+            }
+            if (ce.getOperator() == CigarOperator.D) {
+                indelcnt++;
+                indellen = indellen + ce.getLength();
+            }
+            if (ce.getOperator() == CigarOperator.S) {
+                sclen = sclen + ce.getLength();
+            }
+
+        }
+
+        if (indelcnt >= 3)return true;
+
+        Integer nm = sam.getIntegerAttribute("NM");
+        if(nm!=null){
+            nm = nm - indellen;
+        }else{
+            nm=0;
+        }
+        if (sam.getMappingQuality() <= 15 && nm>=2) {
+            return true;
+        }
+        double errorratio = (double)nm/(double)(seqlen-sclen);
+        if(errorratio>0.15){
+            return true;
+        }
+
+        return false;
+    }
+
+
+
+}


### PR DESCRIPTION
This PR adds the threshold for normal INDELs so that the karkinos output them as somatic if INDEL reads exist in a normal sample and it is less than 0.05% AF and less than 2, and if tumor AF is greater than 20 times and more than ten reads in a tumor sample.

Also, this PR includes the following fixes for the features added in #27.

- Count as mismatches in ends not only SNVs but also INDELs
- Skip if the reads have a low mapping quality
