### PR TITLE
RenameSuggestion

### DIFF
--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java
@@ -285,7 +285,7 @@ public class TumorGenotyper extends ReadWriteBase {
 			sites = cl.getOptionValue("sites");
 		}
 
-		boolean allfileexsist = fileExsistanceCheck(files);
+		boolean allfileexsist = fileExistenceCheck(files);
 		if (!allfileexsist) {
 			return;
 		}
@@ -360,7 +360,7 @@ public class TumorGenotyper extends ReadWriteBase {
 		}
 	}
 
-	protected boolean fileExsistanceCheck(List<String> files) {
+	protected boolean fileExistenceCheck(List<String> files) {
 		for (String s : files) {
 			File f = new File(s);
 			if (!f.exists()) {

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java
@@ -263,7 +263,7 @@ public class SupportReadsCheck extends ReadWriteBase {
 		if (!isindel) {
 			// 20130319 use fixed copynunber 1
 			float fixedcn = 1.0f;
-			adjustedLogt = getAdjuatedLogt(pileUPResult.getGenomeR(), pileUPResult.getALT(), pileuplist, tumorratioss,
+			adjustedLogt = getAdjustedLogt(pileUPResult.getGenomeR(), pileUPResult.getALT(), pileuplist, tumorratioss,
 					fixedcn, normalAF);
 			ret.setLogtAdjusted(adjustedLogt);
 
@@ -941,9 +941,9 @@ public class SupportReadsCheck extends ReadWriteBase {
 	}
 
 	// culculate adjusted tumor ratio
-	private float getAdjuatedLogt(char genomeR, char alt, List<BaseandQData> pileuplist, double tumorratio,
-			double copynumber, double normalAF) {
-		return OddRatioCalculator.getAdjuatedLogt(genomeR, alt, pileuplist, tumorratio, copynumber, normalAF);
+	private float getAdjustedLogt(char genomeR, char alt, List<BaseandQData> pileuplist, double tumorratio,
+								  double copynumber, double normalAF) {
+		return OddRatioCalculator.getAdjustedLogt(genomeR, alt, pileuplist, tumorratio, copynumber, normalAF);
 	}
 
 	private float getSoftClipRate(List<SAMRecord> supportreads) {

--- a/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/OddRatioCalculator.java
+++ b/src/main/java/jp/ac/utokyo/rcast/karkinos/utils/OddRatioCalculator.java
@@ -21,8 +21,8 @@ import java.util.List;
 import jp.ac.utokyo.rcast.karkinos.filter.BaseandQData;
 
 public class OddRatioCalculator {
-	public static float getAdjuatedLogt(char genomeR, char alt,
-			List<BaseandQData> pileuplist, double tumorratio, double copynumber,double normalAF) {
+	public static float getAdjustedLogt(char genomeR, char alt,
+										List<BaseandQData> pileuplist, double tumorratio, double copynumber, double normalAF) {
 		//int copynumbern = getRound(copynumber);
 
 		List<BaseandQData> pileuplistToCheck = getTocheckList(genomeR, alt,


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find several non-descriptive method names in your repository:
```java
/* Non-descriptive Method Name in src/main/java/jp/ac/utokyo/rcast/karkinos/exec/TumorGenotyper.java */
	protected boolean fileExsistanceCheck(List<String> files) {
		for (String s : files) {
			File f = new File(s);
			if (!f.exists()) {
				System.out.println("file does not exsist " + s);
				return false;
			}
		}
		return true;
	}

```
We considered "fileExsistanceCheck" as non-descriptive because it contains a typo (i.e., Exsistance should be Existence).
```java
/* Non-descriptive Method Name in src/main/java/jp/ac/utokyo/rcast/karkinos/filter/SupportReadsCheck.java */
	private float getAdjuatedLogt(char genomeR, char alt, List<BaseandQData> pileuplist, double tumorratio,
			double copynumber, double normalAF) {
		return OddRatioCalculator.getAdjuatedLogt(genomeR, alt, pileuplist, tumorratio, copynumber, normalAF);
	}
/* Non-descriptive Method Name in src/main/java/jp/ac/utokyo/rcast/karkinos/utils/OddRatioCalculator.java */
	public static float getAdjuatedLogt(char genomeR, char alt,
			List<BaseandQData> pileuplist, double tumorratio, double copynumber,double normalAF) {
		//int copynumbern = getRound(copynumber);

		List<BaseandQData> pileuplistToCheck = getTocheckList(genomeR, alt,
				pileuplist, tumorratio, copynumber,normalAF);

		double reflikehood = 0;
		double altlikehood = 0;
		for (BaseandQData data : pileuplistToCheck) {
			double qual0 = (int) data.getQual() & 0xFF;
			qual0 = qual0 * 0.1;
			double pNomatch = (1 / Math.pow(10, qual0));
			double pmathch = 1 - pNomatch;

			if (equalChar(data.getBase(), genomeR)) {
				reflikehood = reflikehood + pmathch;
				altlikehood = altlikehood + (pNomatch / (double) 3);
			} else {
				reflikehood = reflikehood + (pNomatch / (double) 3);
				altlikehood = altlikehood + pmathch;
			}
		}
		double d = altlikehood / reflikehood;
		return (float) (Math.log10(d));
	}
```
We considered "getAdjuatedLogt" as non-descriptive because it contains a typo (i.e., Adjuated should be Adjusted). 

We have corrected them and commited a pull request.



Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.